### PR TITLE
Allow the user to configure build parallelism

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -11,7 +11,7 @@ function compile_install {
   eval ${CMAKE} ${CMAKE_OPTIONS} ../
 
   # Compile
-  make -j 28 clang ;
+  make -j "${LLVM_INSTALLER_CORES:=28}" clang ;
   echo "" ;
 
   # Install


### PR DESCRIPTION
On peroni 28 cores makes sense, but on my mac it uses all my ram and breaks everything :)

This is for the dep project (https://github.com/arcana-lab/deps) which is an outlining of a few tools I use in alaska to compile LLVM, Noelle, and gclang in one set of scripts (on machines other than peroni)